### PR TITLE
Fix: Explicitly define setter/getter methods for PasswordReset

### DIFF
--- a/src/com/fuse/dao/PasswordReset.java
+++ b/src/com/fuse/dao/PasswordReset.java
@@ -10,11 +10,10 @@ import javax.persistence.Id;
 import javax.persistence.ManyToOne;
 import javax.persistence.TableGenerator;
 
-import lombok.Data;
+import lombok.*;
 
 
 @Entity
-@Data
 public class PasswordReset {
 	@Id
 	@GeneratedValue(strategy = GenerationType.TABLE, generator = "resetGen")
@@ -31,4 +30,29 @@ public class PasswordReset {
 	private Date created;
 	@ManyToOne(fetch = FetchType.EAGER)
 	private User user;
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    public void setUser(User user) {
+        this.user = user;
+    }
+
+    public Date getCreated() {
+        return created;
+    }
+
+    public void setCreated(Date created) {
+        this.created = created;
+    }
+	
 }


### PR DESCRIPTION
- Resolved compilation errors related to missing setKey(), setUser(), and setCreated() methods in PasswordReset.
- Lombok's @Data annotation was present but did not generate the expected methods.
- Added explicit setter and getter methods to ensure compatibility across different environments.