### PR TITLE
Fix remediation table rendering by emitting valid JSON

### DIFF
--- a/WebContent/WEB-INF/jsp/remediation/vulnsJson.jsp
+++ b/WebContent/WEB-INF/jsp/remediation/vulnsJson.jsp
@@ -1,30 +1,29 @@
 <%@page import="org.apache.struts2.components.Include"%><%@ page language="java" contentType="application/json; charset=UTF-8"
     pageEncoding="UTF-8"%><%@ taglib prefix="s" uri="/struts-tags" %><% boolean first=true;%>{ "data" : [<s:iterator value="combos">
 <% if(first){ first=false;}else{ %>,<%}%>[ "<input class='remselect' type='checkbox' onclick='return false'/>",
-"<s:property value="vuln.name" escapeJavaScript="true"/>" , 
-"<s:property value="assessment.appId"/>\n<s:property value="assessment.name"/>", 
-"<s:iterator value="assessment.assessor"><s:property value="fname" escapeJavaScript="true"/> <s:property value="lname" escapeJavaScript="true"/>\n</s:iterator>",
-"<s:property value="vuln.tracking" escapeJavaScript="true"/>" , 
+"<s:property value="jsonEscape(vuln.name)"/>" ,
+"<s:property value="jsonEscape(assessment.appId)"/>\n<s:property value="jsonEscape(assessment.name)"/>",
+"<s:iterator value="assessment.assessor"><s:property value="jsonEscape(fname)"/> <s:property value="jsonEscape(lname)"/>\n</s:iterator>",
+"<s:property value="jsonEscape(vuln.tracking)"/>" ,
 "<s:if test="isVer">Out for Verification</s:if>",
-"<s:property value="vuln.overallStr" escapeJavaScript="true"/>" ,  
+"<s:property value="jsonEscape(vuln.overallStr)"/>" ,
 <s:if test="vuln.closed== null">
 "<s:date name="vuln.opened"  format="MM/dd/yyyy"/>",
 </s:if>
 <s:else>
-"<s:date name="vuln.opened"  format="MM/dd/yyyy"/>", 
+"<s:date name="vuln.opened"  format="MM/dd/yyyy"/>",
 </s:else>
-"<s:date name="vuln.devClosed" format="MM/dd/yyyy"/>", 
-"<s:date name="vuln.closed" format="MM/dd/yyyy"/>", 
+"<s:date name="vuln.devClosed" format="MM/dd/yyyy"/>",
+"<s:date name="vuln.closed" format="MM/dd/yyyy"/>",
 {},
-{ 
-	"aid" :"<s:property value="assessment.id"/>", 
-	"appId" :"<s:property value="assessment.appId" escapeJavaScript="true" />", 
-	"vid" : "<s:property value="vuln.id"/>", 
-	"dist" : "<s:property value="assessment.DistributionList" escapeJavaScript="true"/>", 
-	"notes" : "<s:property value="assessment.AccessNotes"/>",
-	"name" : "<s:property value="assessment.name" escapeJavaScript="true"/>",
-	"vulnName" : "<s:property value="vuln.name" escapeJavaScript="true"/>",
-	"tracking" : "<s:property value="vuln.tracking" escapeJavaScript="true"/>",
+{
+	"aid" :"<s:property value="assessment.id"/>",
+	"appId" :"<s:property value="jsonEscape(assessment.appId)" />",
+	"vid" : "<s:property value="vuln.id"/>",
+	"dist" : "<s:property value="jsonEscape(assessment.DistributionList)"/>",
+	"name" : "<s:property value="jsonEscape(assessment.name)"/>",
+	"vulnName" : "<s:property value="jsonEscape(vuln.name)"/>",
+	"tracking" : "<s:property value="jsonEscape(vuln.tracking)"/>",
 	"isVer" : ${isVer},
 	"severity" : {
 		"overall" :  "${vuln.overall}",
@@ -33,15 +32,15 @@
 	},
 	"reports": [<s:iterator value="reports" status="stat">
 	<s:if test="!#stat.first">,</s:if>
-	{	
-		"name": "<s:property value="assessment.name" escapeJavaScript="true"/> - <s:property value="assessment.type.type" escapeJavaScript="true"/> <s:if test="retest == true">Retest </s:if>Report.docx", 
-		"type": "<s:property value="assessment.type.type" escapeJavaScript="true"/> <s:if test="retest == true">Retest</s:if>", 
-		"updated": "<s:date name="gentime" format="MM-dd-yyyy hh:mm:ss"/>", 
+	{
+		"name": "<s:property value="jsonEscape(assessment.name)"/> - <s:property value="jsonEscape(assessment.type.type)"/> <s:if test="retest == true">Retest </s:if>Report.docx",
+		"type": "<s:property value="jsonEscape(assessment.type.type)"/> <s:if test="retest == true">Retest</s:if>",
+		"updated": "<s:date name="gentime" format="MM-dd-yyyy hh:mm:ss"/>",
 		"guid" : "<s:property value="filename"/>",
 		"isRetest": <s:property value="retest"/>
 	}</s:iterator>]
 }]
-</s:iterator>], 
-"recordsTotal" : ${count}, 
-"recordsFiltered" :  ${count} 
+</s:iterator>],
+"recordsTotal" : ${count},
+"recordsFiltered" :  ${count}
 }

--- a/src/com/fuse/actions/remediation/OpenVulns.java
+++ b/src/com/fuse/actions/remediation/OpenVulns.java
@@ -17,6 +17,7 @@ import com.fuse.dao.Vulnerability;
 import com.fuse.dao.query.VulnerabilityQueries;
 import com.fuse.utils.Combo;
 import com.fuse.utils.FSUtils;
+import com.fasterxml.jackson.core.io.JsonStringEncoder;
 import com.mongodb.BasicDBObject;
 
 @Namespace("/portal")
@@ -379,6 +380,20 @@ public class OpenVulns extends FSActionSupport {
 
 	public void setCount(Long count) {
 		this.count = count;
+	}
+
+	/**
+	 * Escapes a value for safe inclusion inside a JSON string literal. Struts'
+	 * escapeJavaScript escapes a single quote as \' which is NOT a valid JSON
+	 * escape sequence and breaks JSON.parse on the client (the DataTable). This
+	 * produces strictly valid JSON: it escapes ", \\ and control characters and
+	 * leaves single quotes untouched.
+	 */
+	public String jsonEscape(String value) {
+		if (value == null) {
+			return "";
+		}
+		return new String(JsonStringEncoder.getInstance().quoteAsString(value));
 	}
 	
 


### PR DESCRIPTION
Struts' escapeJavaScript escapes a single quote as \' which is not a
valid JSON escape sequence and breaks JSON.parse for the remediation
DataTable when a value contains a quote. Add a jsonEscape() helper backed
by Jackson's JsonStringEncoder and use it for the string values rendered
in vulnsJson.jsp.
